### PR TITLE
docs: add backtesting usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,27 @@ python keylevels.py --tickers AAPL MSFT --schedule 16:00
 ```
 
 The tool can be scheduled by external systems such as cron as well.
+
+## Backtesting
+
+To evaluate how price has historically reacted to the detected levels, use the
+`--backtest` flag. The numeric argument sets the *lookahead* window in bars for
+checking whether price bounces or breaks a level.
+
+```bash
+python keylevels.py --tickers AAPL --backtest 10
+```
+
+The backtest currently reports:
+
+* **Bounce ratio** – percentage of touches that result in a bounce within the
+  lookahead window.
+* **Average move** – mean price change following bounces or breaks.
+
+The logic assumes the same historical data used for level detection and
+evaluates behaviour over the next `N` bars where `N` is the `--backtest`
+value.
+
+No extra dependencies are required beyond those in `requirements.txt`, but make
+sure recent versions of `pandas` and `yfinance` are installed (e.g.
+`pandas>=1.5` and `yfinance>=0.2`) so the backtest calculations work properly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas
-yfinance
+pandas>=1.5
+yfinance>=0.2
 plotly
 schedule


### PR DESCRIPTION
## Summary
- document how to invoke backtesting with `--backtest`
- explain bounce ratio and average move metrics along with lookahead assumption
- specify minimum pandas and yfinance versions for backtest support

## Testing
- `python -m py_compile keylevels.py`


------
https://chatgpt.com/codex/tasks/task_e_688dc4222ac8832ca937850b11d26158