### PR TITLE
Add distinct training and testing windows for backtests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ python keylevels.py --tickers AAPL MSFT
 ```
 
 By default the script analyses daily, hourly, 4‑hour and weekly data starting
-from `2024-01-01` and prints the nearest key levels above and below the latest
-close.
+from `2024-01-01` (configurable via `--train-start`) and prints the nearest key
+levels above and below the latest close. Dates should be supplied in
+`YYYY-MM-DD` format.
 
 To keep the script running and execute the analysis every day at a specific
 local time use the `--schedule` option (requires the `schedule` package):
@@ -33,12 +34,18 @@ The tool can be scheduled by external systems such as cron as well.
 ## Backtesting
 
 To evaluate how price has historically reacted to the detected levels, use the
-`--backtest` flag. The numeric argument sets the *lookahead* window in bars for
-checking whether price bounces or breaks a level.
+`--backtest` flag along with separate training and testing windows. `--train-start`
+defines the beginning of the training period used for level detection, while
+`--test-start` marks the beginning of the testing period. The numeric argument
+to `--backtest` sets the *lookahead* window in bars for checking whether price
+bounces or breaks a level.
 
 ```bash
-python keylevels.py --tickers AAPL --backtest 10
+python keylevels.py --tickers AAPL --backtest 10 --train-start 2020-01-01 --test-start 2024-01-01
 ```
+
+The training window must start before the testing window; otherwise the program
+will raise an error.
 
 The backtest currently reports:
 
@@ -46,9 +53,9 @@ The backtest currently reports:
   lookahead window.
 * **Average move** – mean price change following bounces or breaks.
 
-The logic assumes the same historical data used for level detection and
-evaluates behaviour over the next `N` bars where `N` is the `--backtest`
-value.
+During backtesting, levels are detected using data from the training window
+and then evaluated on the separate testing window. Each touch is examined over
+the next `N` bars, where `N` is the value supplied to `--backtest`.
 
 No extra dependencies are required beyond those in `requirements.txt`, but make
 sure recent versions of `pandas` and `yfinance` are installed (e.g.


### PR DESCRIPTION
## Summary
- rename `--start` to `--train-start` and add `--test-start`
- ensure backtests validate training precedes testing
- document date formats and backtesting examples in README

## Testing
- `python -m py_compile keylevels.py`
- `python keylevels.py --help`
- `python keylevels.py --tickers AAPL --backtest 5 --train-start 2020-01-01`
- `python keylevels.py --tickers AAPL --backtest 5 --train-start 2024-01-01 --test-start 2023-01-01`
- `python keylevels.py --tickers AAPL --backtest 1 --train-start 2024-01-01 --test-start 2024-01-05` *(fails: ProxyError('Failed to perform, curl: (56) CONNECT tunnel failed, response 403. See https://curl.se/libcurl/c/libcurl-errors.html first for more details.'))*

------
https://chatgpt.com/codex/tasks/task_e_688f23459738832caee9641f5612273f